### PR TITLE
feat: fetch all active products

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,7 +7,9 @@ import ProductList from "../components/ProductList";
 import ProductGrid from "../components/ProductGrid";
 
 export async function getStaticProps() {
-  const { data: products } = await commerce.products.list();
+  const { data } = await commerce.products.list();
+
+  const products = data.filter(({ active }) => active);
 
   return {
     props: {


### PR DESCRIPTION
To make it simpler for new stores using this example, we'll fetch all products.

In our demo use case, we use a "inactive" product as a promotional item, which
we can document how to do this later.
